### PR TITLE
fix: package json main and types path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Google Font Metadata will log all notable changes within this file.
 
+# [3.0.1](https://github.com/fontsource/google-font-metadata/releases/tag/v3.0.1)
+
+# Fixes
+
+- Resolve package.json main and types paths. You could not load the modules in the previous version. [#74](https://github.com/fontsource/google-font-metadata/pull/74)
+
 # [3.0.0](https://github.com/fontsource/google-font-metadata/releases/tag/v3.0.0)
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -59,9 +59,8 @@
     "lib/*",
     "data/*"
   ],
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "homepage": "https://github.com/fontsource/google-font-metadata",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix main and types properties in package.json leading to the package not loading on import.