### PR TITLE
fix: add type assertion for pkgroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Google Font Metadata will log all notable changes within this file.
 
+# [4.1.4](https://github.com/fontsource/google-font-metadata/releases/tag/v4.1.4)
+
+## Fixes
+
+- Add additional type assertion to please `pkgroll dts`. [#114](https://github.com/fontsource/google-font-metadata/pull/112)
+- Republish with updated dist files.
+
 # [4.1.3](https://github.com/fontsource/google-font-metadata/releases/tag/v4.1.3)
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Google Font Metadata will log all notable changes within this file.
 
 ## Fixes
 
-- Add additional type assertion to please `pkgroll dts`. [#114](https://github.com/fontsource/google-font-metadata/pull/112)
+- Add additional type assertion to please `pkgroll dts`. [#114](https://github.com/fontsource/google-font-metadata/pull/114)
 - Republish with updated dist files.
 
 # [4.1.3](https://github.com/fontsource/google-font-metadata/releases/tag/v4.1.3)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "google-font-metadata",
 	"description": "A metadata generator for Google Fonts.",
-	"version": "4.1.3",
+	"version": "4.1.4",
 	"author": "Ayuhito <hello@ayuhito.com>",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/src/variable-parser.ts
+++ b/src/variable-parser.ts
@@ -200,7 +200,7 @@ export const fetchCSS = async (url: string) => {
 export const fetchAllCSS = async (links: Links) =>
 	Promise.all(
 		Object.keys(links).map(async (key) => [key, await fetchCSS(links[key])])
-	);
+	) as Promise<string[][]>; // Additional type assertion needed for pkgroll dts plugin
 
 export const parseCSS = (cssTuple: string[][]) => {
 	const fontVariants: FontVariantsVariable = {};


### PR DESCRIPTION
`pkgroll dts` was not letting the build succeed without this specific type assertion on a Got request.