### PR TITLE
fix: expose axis registry functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Google Font Metadata will log all notable changes within this file.
 
+# [4.2.1](https://github.com/fontsource/google-font-metadata/releases/tag/v4.2.1)
+
+## Fixes
+
+- Expose axis registry functions. [#118](https://github.com/fontsource/google-font-metadata/pull/118)
+
 # [4.2.0](https://github.com/fontsource/google-font-metadata/releases/tag/v4.2.0)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -17,8 +17,20 @@ npm install google-font-metadata
 The project exports the following data:
 
 ```ts
-import { APIv1, APIv2, APIVariable } from "google-font-metadata";
-const { APIv1, APIv2, APIVariable } = require("google-font-metadata");
+import {
+	APIv1,
+	APIv2,
+	APIVariable,
+	APILicense,
+	APIRegistry,
+} from "google-font-metadata";
+const {
+	APIv1,
+	APIv2,
+	APIVariable,
+	APILicense,
+	APIRegistry,
+} = require("google-font-metadata");
 
 console.dir(APIv2);
 ```
@@ -229,7 +241,7 @@ Scrapes the [Google Fonts Attribution](https://fonts.google.com/attribution) pag
 
 Exports [`data/licenses.json`](https://github.com/fontsource/google-font-metadata/tree/main/data/licenses.json)
 
-## Axis Registry
+## APIRegistry
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "google-font-metadata",
 	"description": "A metadata generator for Google Fonts.",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"author": "Ayuhito <hello@ayuhito.com>",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/src/data.ts
+++ b/src/data.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'pathe';
 
 import type {
 	APIResponse,
+	AxesObject,
 	FontObjectV1,
 	FontObjectV2,
 	FontObjectVariable,
@@ -103,4 +104,17 @@ const APILicense = JSON.parse(
 	)
 ) as Licenses;
 
-export { APIDirect, APILicense, APIv1, APIv2, APIVariable, APIVariableDirect };
+/**
+	* This returns the axis registry of the supported Google Font variable axes.
+	* {@link https://github.com/googlefonts/axisregistry}
+	*
+	* @remarks This can be updated using `npx gfm parse --registry`.
+*/
+const APIRegistry = JSON.parse(
+	fs.readFileSync(
+		join(dirname(fileURLToPath(import.meta.url)), '../data/axis-registry.json'),
+		'utf8'
+	)
+) as AxesObject[];
+
+export { APIDirect, APILicense, APIRegistry,APIv1, APIv2, APIVariable, APIVariableDirect };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 export { fetchAPI } from './api-gen';
 export { parsev1 } from './api-parser-v1';
 export { parsev2 } from './api-parser-v2';
+export { generateAxis } from './axis-gen';
 export {
 	APIDirect,
 	APILicense,
+	APIRegistry,
 	APIv1,
 	APIv2,
 	APIVariable,
@@ -12,6 +14,7 @@ export {
 export { parseLicenses } from './license';
 export type {
 	APIResponse,
+	AxesObject,
 	FontObject,
 	FontObjectV1,
 	FontObjectV2,

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ type StandardAxes = typeof STANDARD_AXES[number];
 
 const isStandardAxesKey = (axesKey: string): axesKey is StandardAxes =>
 	STANDARD_AXES.includes(axesKey as StandardAxes);
-interface AxesObject {
+export interface AxesObject {
 	name: string;
 	tag: string;
 	min: number;


### PR DESCRIPTION
I need to access the registry functions for the Fontsource CLI. Forgot to include that.