### PR TITLE
fix: rename fallback to defsubset

### DIFF
--- a/.github/workflows/cron-run.yml
+++ b/.github/workflows/cron-run.yml
@@ -22,7 +22,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Generate API
         run: pnpm run cli generate $GOOGLE_API_KEY

--- a/.github/workflows/cron-run.yml
+++ b/.github/workflows/cron-run.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18"
-          cache: "pnpm"
 
       - name: Install
         run: pnpm install

--- a/.github/workflows/manual-run-force.yml
+++ b/.github/workflows/manual-run-force.yml
@@ -20,7 +20,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Generate API
         run: pnpm run cli generate $GOOGLE_API_KEY

--- a/.github/workflows/manual-run-force.yml
+++ b/.github/workflows/manual-run-force.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18"
-          cache: "pnpm"
 
       - name: Install
         run: pnpm install

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -20,7 +20,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Generate API
         run: pnpm run cli generate $GOOGLE_API_KEY

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18"
-          cache: "pnpm"
 
       - name: Install
         run: pnpm install

--- a/data/icons-response.json
+++ b/data/icons-response.json
@@ -43,8 +43,8 @@
     "family": "Material Symbols Outlined",
     "variants": ["100", "200", "300", "regular", "500", "600", "700"],
     "subsets": ["latin"],
-    "version": "v107",
-    "lastModified": "2023-04-20",
+    "version": "v108",
+    "lastModified": "2023-04-27",
     "category": "icons",
     "axes": {
       "FILL": {"min": "0", "max": "1", "default": "0", "step": "1"},
@@ -57,8 +57,8 @@
     "family": "Material Symbols Rounded",
     "variants": ["100", "200", "300", "regular", "500", "600", "700"],
     "subsets": ["latin"],
-    "version": "v106",
-    "lastModified": "2023-04-20",
+    "version": "v107",
+    "lastModified": "2023-04-27",
     "category": "icons",
     "axes": {
       "FILL": {"min": "0", "max": "1", "default": "0", "step": "1"},
@@ -71,8 +71,8 @@
     "family": "Material Symbols Sharp",
     "variants": ["100", "200", "300", "regular", "500", "600", "700"],
     "subsets": ["latin"],
-    "version": "v103",
-    "lastModified": "2023-04-20",
+    "version": "v104",
+    "lastModified": "2023-04-27",
     "category": "icons",
     "axes": {
       "FILL": {"min": "0", "max": "1", "default": "0", "step": "1"},

--- a/data/icons-static.json
+++ b/data/icons-static.json
@@ -9,7 +9,7 @@
     "variants": {
       "400": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialicons/v140/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2",
               "woff": "https://fonts.gstatic.com/s/materialicons/v140/flUhRq6tzZclQEJ-Vdg-IuiaDsNaIhQ8tQ.woff",
@@ -34,7 +34,7 @@
     "variants": {
       "400": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialiconsoutlined/v109/gok-H7zzDkdnRel8-DQ6KAXJ69wP1tGnf4ZGhUce.woff2",
               "woff": "https://fonts.gstatic.com/s/materialiconsoutlined/v109/gok-H7zzDkdnRel8-DQ6KAXJ69wP1tGnf4ZGhUcYl5euIg.woff",
@@ -59,7 +59,7 @@
     "variants": {
       "400": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialiconsround/v108/LDItaoyNOAY6Uewc665JcIzCKsKc_M9flwmP.woff2",
               "woff": "https://fonts.gstatic.com/s/materialiconsround/v108/LDItaoyNOAY6Uewc665JcIzCKsKc_M9flwmJq_HTTw.woff",
@@ -84,7 +84,7 @@
     "variants": {
       "400": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialiconssharp/v109/oPWQ_lt5nv4pWNJpghLP75WiFR4kLh3kvmvR.woff2",
               "woff": "https://fonts.gstatic.com/s/materialiconssharp/v109/oPWQ_lt5nv4pWNJpghLP75WiFR4kLh3kvmvXImcycg.woff",
@@ -109,7 +109,7 @@
     "variants": {
       "400": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialiconstwotone/v112/hESh6WRmNCxEqUmNyh3JDeGxjVVyMg4tHGctNCu0.woff2",
               "woff": "https://fonts.gstatic.com/s/materialiconstwotone/v112/hESh6WRmNCxEqUmNyh3JDeGxjVVyMg4tHGctNCuyNjbrHg.woff",
@@ -134,7 +134,7 @@
     "variants": {
       "100": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHeej.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHeelbd5zrAAu.woff",
@@ -145,7 +145,7 @@
       },
       "200": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDAvHOej.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDAvHOelbd5zrAAu.woff",
@@ -156,7 +156,7 @@
       },
       "300": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDDxHOej.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDDxHOelbd5zrAAu.woff",
@@ -167,7 +167,7 @@
       },
       "400": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOej.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOelbd5zrAAu.woff",
@@ -178,7 +178,7 @@
       },
       "500": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCdHOej.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCdHOelbd5zrAAu.woff",
@@ -189,7 +189,7 @@
       },
       "600": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBxG-ej.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBxG-elbd5zrAAu.woff",
@@ -200,7 +200,7 @@
       },
       "700": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBIG-ej.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v108/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBIG-elbd5zrAAu.woff",
@@ -211,8 +211,8 @@
       }
     },
     "defSubset": "latin",
-    "lastModified": "2023-04-20",
-    "version": "v107",
+    "lastModified": "2023-04-27",
+    "version": "v108",
     "category": "icons"
   },
   "material-symbols-rounded": {
@@ -225,7 +225,7 @@
     "variants": {
       "100": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIekXxc.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIekXxGJKJBiOaw.woff",
@@ -236,7 +236,7 @@
       },
       "200": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rAelXxc.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rAelXxGJKJBiOaw.woff",
@@ -247,7 +247,7 @@
       },
       "300": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rNmlXxc.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rNmlXxGJKJBiOaw.woff",
@@ -258,7 +258,7 @@
       },
       "400": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelXxc.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelXxGJKJBiOaw.woff",
@@ -269,7 +269,7 @@
       },
       "500": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rLWlXxc.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rLWlXxGJKJBiOaw.woff",
@@ -280,7 +280,7 @@
       },
       "600": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rFmiXxc.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rFmiXxGJKJBiOaw.woff",
@@ -291,7 +291,7 @@
       },
       "700": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rGCiXxc.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolsrounded/v107/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rGCiXxGJKJBiOaw.woff",
@@ -302,8 +302,8 @@
       }
     },
     "defSubset": "latin",
-    "lastModified": "2023-04-20",
-    "version": "v106",
+    "lastModified": "2023-04-27",
+    "version": "v107",
     "category": "icons"
   },
   "material-symbols-sharp": {
@@ -316,7 +316,7 @@
     "variants": {
       "100": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLozCL.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLozCNJ1H7-3Hn.woff",
@@ -327,7 +327,7 @@
       },
       "200": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxMLojCL.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxMLojCNJ1H7-3Hn.woff",
@@ -338,7 +338,7 @@
       },
       "300": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxPVojCL.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxPVojCNJ1H7-3Hn.woff",
@@ -349,7 +349,7 @@
       },
       "400": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLojCL.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLojCNJ1H7-3Hn.woff",
@@ -360,7 +360,7 @@
       },
       "500": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxO5ojCL.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxO5ojCNJ1H7-3Hn.woff",
@@ -371,7 +371,7 @@
       },
       "600": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNVpTCL.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNVpTCNJ1H7-3Hn.woff",
@@ -382,7 +382,7 @@
       },
       "700": {
         "normal": {
-          "fallback": {
+          "latin": {
             "url": {
               "woff2": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNspTCL.woff2",
               "woff": "https://fonts.gstatic.com/s/materialsymbolssharp/v104/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNspTCNJ1H7-3Hn.woff",
@@ -393,8 +393,8 @@
       }
     },
     "defSubset": "latin",
-    "lastModified": "2023-04-20",
-    "version": "v103",
+    "lastModified": "2023-04-27",
+    "version": "v104",
     "category": "icons"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "google-font-metadata",
 	"description": "A metadata generator for Google Fonts.",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"author": "Ayuhito <hello@ayuhito.com>",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/src/api-parser-v2.ts
+++ b/src/api-parser-v2.ts
@@ -110,6 +110,8 @@ export const processCSS = (
 					throw new TypeError(`Unknown child of comment: ${rule.children}`);
 
 				subset = rule.children.trim();
+				// If subset is fallback, rename it to defSubset
+				if (subset === 'fallback') subset = fontObject[id].defSubset;
 			}
 
 			if (rule.type === '@font-face') {


### PR DESCRIPTION
We determine subsets for a font file link using the comment when parsing the CSS. However, since icons do not necessarily have any defined subsets, Google uses the comment 'fallback' breaks parsing downstream since the provided `defSubset` is `latin`.

This resolves the inconsistency in the API so we don't need to implement hacky checks downstream.

