### PR TITLE
fix: removes comments after a value in axis registry

### DIFF
--- a/data/axis-registry.json
+++ b/data/axis-registry.json
@@ -28,7 +28,7 @@
     "tag": "EHLT",
     "min": 0,
     "max": 1000,
-    "default": null,
+    "default": 12,
     "precision": 0
   },
   {
@@ -52,7 +52,7 @@
     "tag": "EDPT",
     "min": 0,
     "max": 1000,
-    "default": null,
+    "default": 100,
     "precision": 0
   },
   {
@@ -268,7 +268,7 @@
     "tag": "YTFI",
     "min": -1000,
     "max": 2000,
-    "default": null,
+    "default": 600,
     "precision": 0
   },
   {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "google-font-metadata",
 	"description": "A metadata generator for Google Fonts.",
-	"version": "5.1.4",
+	"version": "5.1.5",
 	"author": "Ayuhito <hello@ayuhito.com>",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/src/axis-gen.ts
+++ b/src/axis-gen.ts
@@ -78,7 +78,7 @@ const downloadAxis = async (axis: AxisProto): Promise<AxisObject> => {
 	for (const line of lines) {
 		const [key, value] = line.split(':');
 		// @ts-ignore - these are known tags
-		data[key.trim()] = value.trim().replace(/"/g, '');
+		data[key.trim()] = value.split('#')[0].trim().replace(/"/g, ''); // remove comments and quotes
 	}
 
 	const result = {


### PR DESCRIPTION
[Comments after a value](https://github.com/googlefonts/axisregistry/blob/2d08f1a1890851bc7860a6fd8e9b8b49597a384d/Lib/axisregistry/data/edge_highlight.textproto#LL5C1-L5C1) in the axis registry broke the ability to read values from that line. This checks for comments and removes them if necessary.