### PR TITLE
fix: use defsubset if there is no comment in CSS

### DIFF
--- a/src/api-parser-v2.ts
+++ b/src/api-parser-v2.ts
@@ -82,6 +82,7 @@ export const processCSS = (
 	font: APIResponse,
 ) => {
 	const id = font.family.replaceAll(/\s/g, '-').toLowerCase();
+	const defSubset = font.subsets.includes('latin') ? 'latin' : font.subsets[0];
 
 	const fontObject: FontObjectV2 = {
 		[id]: {
@@ -92,7 +93,7 @@ export const processCSS = (
 			styles: [],
 			unicodeRange: {},
 			variants: {},
-			defSubset: font.subsets.includes('latin') ? 'latin' : font.subsets[0],
+			defSubset,
 			lastModified: font.lastModified,
 			version: font.version,
 			category: font.category,
@@ -102,7 +103,7 @@ export const processCSS = (
 	for (const extension of css) {
 		const rules = compile(extension);
 
-		let subset = '';
+		let subset = defSubset ?? 'latin';
 		let fontStyle = '';
 		let fontWeight = '';
 		for (const rule of rules) {
@@ -218,6 +219,16 @@ export const processCSS = (
 			}
 		}
 	}
+
+	// If unicode-range is empty, but the font has a subset, add a fallback range that covers all characters
+	if (
+		Object.keys(fontObject[id].unicodeRange).length === 0 &&
+		fontObject[id].defSubset
+	) {
+		fontObject[id].unicodeRange[fontObject[id].defSubset] =
+			'U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD';
+	}
+
 	return fontObject;
 };
 

--- a/src/variable-parser.ts
+++ b/src/variable-parser.ts
@@ -198,6 +198,7 @@ export const fetchCSS = async (url: string) => {
 
 // [key, css]
 export const fetchAllCSS = async (links: Links) =>
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 	await (Promise.all(
 		Object.keys(links).map(async (key) => [key, await fetchCSS(links[key])]),
 	) as Promise<string[][]>); // Additional type assertion needed for pkgroll dts plugin
@@ -205,7 +206,7 @@ export const fetchAllCSS = async (links: Links) =>
 export const parseCSS = (cssTuple: string[][], defSubset?: string) => {
 	const fontVariants: FontVariantsVariable = {};
 
-	let subset = '';
+	let subset = defSubset ?? 'latin';
 	for (const [key, cssVariant] of cssTuple) {
 		const [fontType, fontStyle] = key.split('.');
 		const rules = compile(cssVariant);


### PR DESCRIPTION
Closes #132. If the generated CSS does not include a comment in the CSS to parse the subset, fallback to the default subset for generating APIv2 and variable metadata. 

This does not address the underlying issue where Google is not providing the static instances to the fonts in question, however, that's an upstream issue which they may choose to solve on their own. Manually verifying it ourselves is more likely to be harder to maintain and it would require a lot more manual intervention on our end to keep things up to date.